### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # darimanastart
+WHEN you enter a traditional Japanese home, you go through a neat, latticed sliding door. Once inside, you will probably see a decorated folding screen. In the room, you may see other decorations, such as dolls, hanging scrolls with paintings or calligraphy, lampshades, fancy containers or boxes. All these varied items have one thing in common​—they are made of washi—​the versatile Japanese handmade paper.
+
+A Long History
+
+The Japanese imported the art of papermaking from China in the seventh century C.E. For more than a thousand years, handmade washi reigned supreme as Japan’s only paper. In some areas, entire villages built their livelihood around papermaking; some of them became famous in their own right for the fine paper they produced.
+
+By the latter half of the 19th century, papermaking had reached its golden age in Japan. About a thousand paper factories flourished throughout the country. With the advent of the industrial revolution, however, washi making, along with other hand industries, began to decline. Yet, even today the tradition of handmade washi is still being kept alive in certain areas for its artistic qualities.


### PR DESCRIPTION
Ancient Handmade Paper

WHEN you enter a traditional Japanese home, you go through a neat, latticed sliding door. Once inside, you will probably see a decorated folding screen. In the room, you may see other decorations, such as dolls, hanging scrolls with paintings or calligraphy, lampshades, fancy containers or boxes. All these varied items have one thing in common​—they are made of washi—​the versatile Japanese handmade paper.

A Long History

The Japanese imported the art of papermaking from China in the seventh century C.E. For more than a thousand years, handmade washi reigned supreme as Japan’s only paper. In some areas, entire villages built their livelihood around papermaking; some of them became famous in their own right for the fine paper they produced.

By the latter half of the 19th century, papermaking had reached its golden age in Japan. About a thousand paper factories flourished throughout the country. With the advent of the industrial revolution, however, washi making, along with other hand industries, began to decline. Yet, even today the tradition of handmade washi is still being kept alive in certain areas for its artistic qualities.